### PR TITLE
Disable jacoco coverage in EI profile

### DIFF
--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -132,4 +132,4 @@ DB_META_DATA = {
                                 "product-is": {},
                                 "product-ei": {}}
                    }}
-MEDIATION_TEST_MODULES={"tests-mediator-1", "tests-mediator-2", "tests-service", "tests-transport", "tests-patches", "tests-sample", "tests-other"}
+MEDIATION_TEST_MODULES = {"tests-mediator-1", "tests-mediator-2", "tests-service", "tests-transport", "tests-patches", "tests-sample", "tests-other"}

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -132,3 +132,4 @@ DB_META_DATA = {
                                 "product-is": {},
                                 "product-ei": {}}
                    }}
+MEDIATION_TEST_MODULES={"tests-mediator-1", "tests-mediator-2", "tests-service", "tests-transport", "tests-patches", "tests-sample", "tests-other"}


### PR DESCRIPTION
## Purpose
> Disable Jacoco coverage in automation.xml in mediation-tests modules
> Resolves #9

## Goals
> Start up integrator profile in Windows.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes