### PR TITLE
Collect and display JVM metrics 

### DIFF
--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -24,7 +24,7 @@ import shutil
 import logging
 from const import ZIP_FILE_EXTENSION, NS, SURFACE_PLUGIN_ARTIFACT_ID, CARBON_NAME, VALUE_TAG, \
     DEFAULT_ORACLE_SID, MYSQL_DB_ENGINE, ORACLE_DB_ENGINE, LIB_PATH, PRODUCT_STORAGE_DIR_NAME, \
-    DISTRIBUTION_PATH, MSSQL_DB_ENGINE, M2_PATH, DATASOURCE_PATHS
+    DISTRIBUTION_PATH, MSSQL_DB_ENGINE, M2_PATH, DATASOURCE_PATHS, INTEGRATOR, BP, BROKER, ANALYTICS, MICRO_INTG
 
 
 database_url = None
@@ -108,6 +108,43 @@ def modify_distribution_name(element):
     temp = element.text.split("/")
     temp[-1] = dist_name + ZIP_FILE_EXTENSION
     return '/'.join(temp)
+
+
+def attach_jolokia_agent(spath):
+    logger.info('attaching jolokia agent as a java agent')
+    sp = str(spath)
+
+    if sys.platform.startswith('win'):
+        sp = sp + ".bat"
+        if Path.exists(Path(sp)):
+            jolokia_agent = \
+                "-javaagent:C:\\testgrid\\jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http "
+            with open(sp, "r") as in_file:
+                buf = in_file.readlines()
+            with open(sp, "w") as out_file:
+                for line in buf:
+                    if line.startswith("set CMD_LINE_ARGS"):
+                        newline = str(line).replace("CMD_LINE_ARGS=", 'CMD_LINE_ARGS=' + jolokia_agent)
+                        line = newline
+                        logger.info(newline)
+                    out_file.write(line)
+        else:
+            logger.info("couldn't attach jolokia to file, script not available " + sp);
+    else:
+        sp = sp + ".sh"
+        if Path.exists(Path(sp)):
+            jolokia_agent = \
+                "    -javaagent:/opt/wso2/jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http \\\n"
+            with open(sp, "r") as in_file:
+                buf = in_file.readlines()
+            with open(sp, "w") as out_file:
+                for line in buf:
+                    if line == "    $JAVACMD \\\n":
+                        line = line + jolokia_agent
+                        logger.info(line)
+                    out_file.write(line)
+        else:
+            logger.info("couldn't attach jolokia to file, script not available " + sp);
 
 
 # Since we have added a method to clone a given git branch and checkout to the latest released tag it is not required to
@@ -231,8 +268,13 @@ def configure_product(name, id, db_config, ws, product_version):
         storage_zip_abs_path = Path(storage_dir_abs_path / zip_name)
         storage_dist_abs_path = Path(storage_dir_abs_path / dist_name)
         configured_dist_storing_loc = Path(target_dir_abs_path / dist_name)
+        script_name = [INTEGRATOR, BP, BROKER, ANALYTICS, MICRO_INTG]
 
         extract_product(storage_zip_abs_path)
+        for scripts in script_name:
+            script_path = Path(storage_dist_abs_path / Path(scripts))
+            attach_jolokia_agent(script_path)
+
         copy_jar_file(Path(database_config['sql_driver_location']), Path(storage_dist_abs_path / LIB_PATH[product_id]))
         modify_datasources()
         os.remove(str(storage_zip_abs_path))

--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -126,7 +126,6 @@ def attach_jolokia_agent(spath):
                     if line.startswith("set CMD_LINE_ARGS"):
                         newline = str(line).replace("CMD_LINE_ARGS=", 'CMD_LINE_ARGS=' + jolokia_agent)
                         line = newline
-                        logger.info(newline)
                     out_file.write(line)
         else:
             logger.info("couldn't attach jolokia to file, script not available " + sp);
@@ -141,7 +140,6 @@ def attach_jolokia_agent(spath):
                 for line in buf:
                     if line == "    $JAVACMD \\\n":
                         line = line + jolokia_agent
-                        logger.info(line)
                     out_file.write(line)
         else:
             logger.info("couldn't attach jolokia to file, script not available " + sp);

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -17,6 +17,11 @@ ZIP_FILE_EXTENSION = ".zip"
 CARBON_NAME = "carbon.zip"
 VALUE_TAG = "{http://maven.apache.org/POM/4.0.0}value"
 SURFACE_PLUGIN_ARTIFACT_ID = "maven-surefire-plugin"
+INTEGRATOR = "bin/integrator"
+ANALYTICS = "wso2/analytics/wso2/worker/bin/carbon"
+BROKER = "wso2/broker/bin/wso2server"
+BP = "wso2/business-process/bin/wso2server"
+MICRO_INTG = "wso2/micro-integrator/bin/wso2server"
 DATASOURCE_PATHS = {"product-apim": {},
                     "product-is": {},
                     "product-ei": {"CORE": ["conf/datasources/master-datasources.xml"],


### PR DESCRIPTION
## Purpose
Currently only test plans in product EI is not collecting JVM metrics. As a result the product performance dashboard  is displaying a no data for JVM graphs. This PR is to fix that issue

## Goals
Collect and visualize JVM metrics for windows and CentOS

## Approach
Attach Jolokia java agent which will pull JVM metrics from the JVM of the tested product. This is done by modifying wso2server.bat file in product .

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes